### PR TITLE
Fix duplicate heading in worksheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# zoom-in-thinking-routine
+# Zoom-In Thinking Routine
+
+This repository contains HTML templates for running the Zoom-In Thinking Routine with students.
+
+## StudentWorksheet.html
+
+`StudentWorksheet.html` presents a basic worksheet where students can view an image and write observations. The file expects `window.imageData` to be defined before the page loads. Inject this value (for example, using Google Apps Script) so the image displays correctly.
+
+### Saving the Worksheet
+
+Students can press the **Save as PDF** button to trigger `window.print()`. Choose **Save to PDF** in the print dialog to keep a copy of the completed worksheet.

--- a/StudentWorksheet.html
+++ b/StudentWorksheet.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Zoom-In Worksheet</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 2em; }
+        img { max-width: 100%; height: auto; }
+        textarea { width: 100%; height: 4em; margin-top: 1em; }
+        button { margin-top: 1em; }
+    </style>
+    <script>
+        function loadImage() {
+            var img = document.getElementById('zoomImage');
+            if (window.imageData) {
+                img.src = window.imageData;
+            } else {
+                console.warn('window.imageData not provided');
+            }
+        }
+        function saveWorksheet() {
+            window.print();
+        }
+        window.onload = loadImage;
+    </script>
+</head>
+<body>
+    <img id="zoomImage" alt="Zoom-In Image" />
+    <h2>Notes</h2>
+    <textarea placeholder="Write your observations here..."></textarea>
+    <button onclick="saveWorksheet()">Save as PDF</button>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- remove repeated `Zoom-In Thinking Routine` heading from `StudentWorksheet.html`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68413014bae4832ca9db9b3d9a5b47e0